### PR TITLE
increase MAX_CHAIN_ID

### DIFF
--- a/firmware/ethereum.c
+++ b/firmware/ethereum.c
@@ -36,7 +36,7 @@
 #include "memzero.h"
 
 /* maximum supported chain id.  v must fit in an uint32_t. */
-#define MAX_CHAIN_ID 2147483630
+#define MAX_CHAIN_ID 4294967295
 
 static bool ethereum_signing = false;
 static uint32_t data_total, data_left;


### PR DESCRIPTION
increase MAX_CHAIN_ID to full uint32_t to fit with Pirl's Chain ID (3125659152)